### PR TITLE
Fix django sample when running on windows

### DIFF
--- a/django/okteto.yml
+++ b/django/okteto.yml
@@ -1,10 +1,11 @@
 name: web
-command: ["./run_web.sh"]
+command: ["sh", "-c", "./run_web.sh"]
 mountpath: /app
 forward:
   - 8080:8080
 services:
   - name: worker
     mountpath: /app
+    command: ["sh", "-c", "./run_celery.sh"]
 persistentVolume:
   enabled: true


### PR DESCRIPTION
Syncthing only creates `+x` for `*.exe` files.
Wrapping `run_web.sh` in a shell fixes the issue.